### PR TITLE
nft-1110

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-alpha.1",
+  "version": "6.0.0-alpha.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -118,6 +118,10 @@ const POLYGON_TUSD: PaymentTokenDetails = {
   address: '0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756',
   scale: 18,
 };
+const POLYGON_WELT: PaymentTokenDetails = {
+  address: '0x23E8B6A3f6891254988B84Da3738D2bfe5E703b9',
+  scale: 18,
+};
 const FUJI_WETH: PaymentTokenDetails = {
   address: '0x40E71a970Ff1fbd21A53b4d2dbc102Be0E1d574f', // couldn't find weth on fuji, so this is dai
   scale: 18,
@@ -182,7 +186,9 @@ export const ETHEREUM_MAINNET_PAYMENT_TOKEN_RESOLVERS: PaymentTokenResolvers = {
   [PaymentToken.USDC]: ETHEREUM_USDC,
   [PaymentToken.USDT]: ETHEREUM_USDT,
   [PaymentToken.TUSD]: ETHEREUM_TUSD,
+  [PaymentToken.RENT]: SENTINEL,
   [PaymentToken.ACS]: SENTINEL,
+  [PaymentToken.WELT]: SENTINEL,
 };
 
 export const POLYGON_MAINNET_PAYMENT_TOKEN_RESOLVERS: PaymentTokenResolvers = {
@@ -192,7 +198,9 @@ export const POLYGON_MAINNET_PAYMENT_TOKEN_RESOLVERS: PaymentTokenResolvers = {
   [PaymentToken.USDC]: POLYGON_USDC,
   [PaymentToken.USDT]: POLYGON_USDT,
   [PaymentToken.TUSD]: POLYGON_TUSD,
+  [PaymentToken.RENT]: SENTINEL,
   [PaymentToken.ACS]: SENTINEL,
+  [PaymentToken.WELT]: POLYGON_WELT,
 };
 
 export const AVALANCHE_FUJI_TESTNET_PAYMENT_TOKEN_RESOLVERS: PaymentTokenResolvers = {
@@ -202,7 +210,9 @@ export const AVALANCHE_FUJI_TESTNET_PAYMENT_TOKEN_RESOLVERS: PaymentTokenResolve
   [PaymentToken.USDC]: FUJI_USDC,
   [PaymentToken.USDT]: FUJI_USDT,
   [PaymentToken.TUSD]: FUJI_TUSD,
+  [PaymentToken.RENT]: SENTINEL,
   [PaymentToken.ACS]: FUJI_ACS,
+  [PaymentToken.WELT]: SENTINEL,
 };
 
 export const AVALANCHE_MAINNET_PAYMENT_TOKEN_RESOLVERS: PaymentTokenResolvers = {
@@ -212,7 +222,9 @@ export const AVALANCHE_MAINNET_PAYMENT_TOKEN_RESOLVERS: PaymentTokenResolvers = 
   [PaymentToken.USDC]: AVALANCHE_USDC,
   [PaymentToken.USDT]: AVALANCHE_USDT,
   [PaymentToken.TUSD]: AVALANCHE_TUSD,
+  [PaymentToken.RENT]: SENTINEL,
   [PaymentToken.ACS]: AVALANCHE_ACS,
+  [PaymentToken.WELT]: SENTINEL,
 };
 
 // TODO: need to associate these with the resolver contract instance somehow
@@ -231,14 +243,3 @@ export const ALL_NETWORKS: {
   [EVMNetworkType.AVALANCHE_FUJI_TESTNET]: NETWORK_AVALANCHE_FUJI_TESTNET,
   [EVMNetworkType.AVALANCHE_MAINNET]: NETWORK_AVALANCHE_MAINNET,
 };
-
-//// @deprecated
-//export const Resolvers: {
-//  readonly [key in RenftContracts]: PaymentTokenResolvers;
-//} = {
-//  [RenftContracts.SYLVESTER]: NETWORK_RESOLVERS[EVMNetworkType.ETHEREUM_MAINNET],
-//  [RenftContracts.SYLVESTER_POLYGON]: NETWORK_RESOLVERS[EVMNetworkType.POLYGON_MAINNET],
-//  [RenftContracts.AZRAEL]: NETWORK_RESOLVERS[EVMNetworkType.ETHEREUM_MAINNET],
-//  [RenftContracts.WHOOPI_AVALANCHE]: NETWORK_RESOLVERS[EVMNetworkType.AVALANCHE_MAINNET],
-//  [RenftContracts.WHOOPI_FUJI]: NETWORK_RESOLVERS[EVMNetworkType.AVALANCHE_FUJI_TESTNET],
-//};

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -36,6 +36,7 @@ export const DEPLOYMENT_SYLVESTER_ETHEREUM_MAINNET_V0 = {
   version: SylvesterVersion.V0,
 } as const;
 
+// @deprecated - Please use the v1 contract below.
 export const DEPLOYMENT_SYLVESTER_POLYGON_MAINNET_V0 = {
   contractAddress: '0xfA06cFE34C85Ec6b6D29A6a99806cC68BA0018Fe',
   network: NETWORK_POLYGON_MAINNET,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,9 @@ export enum PaymentToken {
   USDC = 3,
   USDT = 4,
   TUSD = 5,
-  ACS = 7, // 6 is reserved for the RENT token when it is released
+  RENT = 6 /* pending */,
+  ACS = 7,
+  WELT = 8,
 }
 
 export type PaymentTokenDetails = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export enum PaymentToken {
   USDC = 3,
   USDT = 4,
   TUSD = 5,
-  RENT = 6 /* pending */,
+  RENT = 6 /* reserved for when RENT token is deployed */,
   ACS = 7,
   WELT = 8,
 }


### PR DESCRIPTION
- Adds support for [$WELT](https://polygonscan.com/address/0x23E8B6A3f6891254988B84Da3738D2bfe5E703b9).
  - This should resolve only to `POLYGON_WELT` for Polygon Mainnet.
  - For all other chains, this `PaymentToken` should evaluate to `SENTINEL`.
- Adds `$RENT`.
  - This should resolve to `SENTINEL` for all chains (unreleased).
- Bumped SDK minor version.
- Uses scale of `18`. ![image](https://user-images.githubusercontent.com/7922333/223123765-f15c5035-2bd0-4a02-9504-be8eaa111020.png)
- Removed dead code.
