### PR TITLE
Bauti/nft 1268 mark the paymenttoken enum as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,10 @@ Take time to familiarise yourself with our [docs](https://docs.renft.io).
 
 For contract name code-mapping see [this](https://docs.renft.io/developers/contracts-name-mapping).
 
+
+## PaymentToken enum Deprecation
+
+The `PaymentToken` enum is deprecated and will be removed in the next major version. Going forward `PaymentToken` will defined as a `keccak256(resolverAddress:chainId:slotId)`. For example, `WETH` on Ethereum will be `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2:1:0`. 
+Notice the slotId of `0`. The slotId is a cardinal parameter to give a single resolver the ability to resolve to multiple token addresses on the same chain. For example, `WBTC` may occupy the second slot given by `0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599:1:1`. 
+
+All the `PaymentToken` values will be available through the reNFT Resolver Subgraph(s). More information to come...

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -20,7 +20,6 @@ import {
   SylvesterVersion,
   WhoopiAbiVersions,
   WhoopiVersion,
-  PaymentTokenKeys,
 } from './types';
 
 export const NETWORK_ETHEREUM_MAINNET: EVMNetworkLike<EVMNetworkType.ETHEREUM_MAINNET> = {
@@ -181,7 +180,7 @@ const AVALANCHE_ACS: PaymentTokenDetails = {
 };
 
 export type PaymentTokenResolvers = {
-  readonly [key in PaymentTokenKeys]: PaymentTokenDetails;
+  readonly [key in PaymentToken]: PaymentTokenDetails;
 };
 
 export type NetworkPaymentTokenResolvers = {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -20,6 +20,7 @@ import {
   SylvesterVersion,
   WhoopiAbiVersions,
   WhoopiVersion,
+  PaymentTokenKeys,
 } from './types';
 
 export const NETWORK_ETHEREUM_MAINNET: EVMNetworkLike<EVMNetworkType.ETHEREUM_MAINNET> = {
@@ -180,7 +181,7 @@ const AVALANCHE_ACS: PaymentTokenDetails = {
 };
 
 export type PaymentTokenResolvers = {
-  readonly [key in PaymentToken]: PaymentTokenDetails;
+  readonly [key in PaymentTokenKeys]: PaymentTokenDetails;
 };
 
 export type NetworkPaymentTokenResolvers = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import {
 
 import { getContractAddressForDeployment } from './deployments';
 
+import { PaymentToken as DefaultPaymentToken } from './types';
+
 export * from './contracts';
 export * from './consts';
 export * from './deployments';
@@ -65,4 +67,23 @@ export const WHOOPI_FUJI_ADDRESS = getContractAddressForDeployment({
 export const WHOOPI_AVALANCHE_ADDRESS = getContractAddressForDeployment({
   network: NETWORK_AVALANCHE_MAINNET,
   contractType: RenftContractType.WHOOPI,
+});
+
+let emittedWarning: boolean = false;
+
+/**
+ * @deprecated This Object is deprecated and will be removed in the next major release.
+ * Please refer to the SDK documentation for further instructions.
+ */
+export const PaymentToken = new Proxy(DefaultPaymentToken, {
+  get: (target, prop, _receiver) => {
+    if (!emittedWarning) {
+      console.warn(
+        'PaymentToken enum is deprecated and will be removed in the next major release. Please refer to the SDK documentation for further instructions.'
+      );
+      emittedWarning = true;
+    }
+
+    return target[prop as keyof typeof target];
+  },
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export type Network =
  * @deprecated This enum is deprecated and will be removed in the next major release.
  * Should only be used internally.
  */
-enum PaymentToken_Deprecated {
+export enum PaymentToken {
   SENTINEL = 0, // denotes non-existence of payment token. i.e. default value signifying it hasn't been set
   WETH = 1,
   DAI = 2,
@@ -40,27 +40,6 @@ enum PaymentToken_Deprecated {
   KNIGHT = 9,
   TOSHI = 10,
 }
-
-export type PaymentToken = typeof PaymentToken_Deprecated[keyof typeof PaymentToken_Deprecated];
-
-let emittedWarning: boolean = false;
-
-/**
- * @deprecated This Object is deprecated and will be removed in the next major release.
- * Please refer to the SDK documentation for further instructions.
- */
-export const PaymentToken = new Proxy(PaymentToken_Deprecated, {
-  get: (target, prop, _receiver) => {
-    if (!emittedWarning) {
-      console.warn(
-        'PaymentToken enum is deprecated and will be removed in the next major release. Please refer to the SDK documentation for further instructions.'
-      );
-      emittedWarning = true;
-    }
-
-    return target[prop as keyof typeof target];
-  },
-});
 
 export type PaymentTokenDetails = {
   address: String;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,9 @@ export type Network =
 
 /**
  * @deprecated This enum is deprecated and will be removed in the next major release.
- * Please refer to the SDK documentation for further instructions. 
+ * Please refer to the SDK documentation for further instructions.
  */
-export enum PaymentToken {
+enum PaymentToken_Deprecated {
   SENTINEL = 0, // denotes non-existence of payment token. i.e. default value signifying it hasn't been set
   WETH = 1,
   DAI = 2,
@@ -40,6 +40,23 @@ export enum PaymentToken {
   KNIGHT = 9,
   TOSHI = 10,
 }
+
+export type PaymentTokenKeys = typeof PaymentToken_Deprecated[keyof typeof PaymentToken_Deprecated];
+
+let emittedWarning: boolean = false;
+
+export const PaymentToken = new Proxy(PaymentToken_Deprecated, {
+  get: (target, prop, _receiver) => {
+    if (!emittedWarning) {
+      console.warn(
+        'PaymentToken enum is deprecated and will be removed in the next major release. Please refer to the SDK documentation for further instructions.'
+      );
+      emittedWarning = true;
+    }
+
+    return target[prop as keyof typeof target];
+  },
+});
 
 export type PaymentTokenDetails = {
   address: String;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ enum PaymentToken_Deprecated {
   TOSHI = 10,
 }
 
-export type PaymentTokenKeys = typeof PaymentToken_Deprecated[keyof typeof PaymentToken_Deprecated];
+export type PaymentToken = typeof PaymentToken_Deprecated[keyof typeof PaymentToken_Deprecated];
 
 let emittedWarning: boolean = false;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type Network =
 
 /**
  * @deprecated This enum is deprecated and will be removed in the next major release.
- * Please refer to the SDK documentation for further instructions.
+ * Should only be used internally.
  */
 enum PaymentToken_Deprecated {
   SENTINEL = 0, // denotes non-existence of payment token. i.e. default value signifying it hasn't been set
@@ -45,6 +45,10 @@ export type PaymentTokenKeys = typeof PaymentToken_Deprecated[keyof typeof Payme
 
 let emittedWarning: boolean = false;
 
+/**
+ * @deprecated This Object is deprecated and will be removed in the next major release.
+ * Please refer to the SDK documentation for further instructions.
+ */
 export const PaymentToken = new Proxy(PaymentToken_Deprecated, {
   get: (target, prop, _receiver) => {
     if (!emittedWarning) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,10 @@ export type Network =
   // | SolanaNetwork
   EVMNetworkLike<EVMNetworkType>;
 
+/**
+ * @deprecated This enum is deprecated and will be removed in the next major release.
+ * Please refer to the SDK documentation for further instructions. 
+ */
 export enum PaymentToken {
   SENTINEL = 0, // denotes non-existence of payment token. i.e. default value signifying it hasn't been set
   WETH = 1,


### PR DESCRIPTION
Deprecate `PaymentToken`. It's usage now emits a `console.warn` message.