### PR TITLE
NFT-1310: fix address checksum + introduce findSingleDeploymentOrThrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   ],
   "dependencies": {
     "@ethersproject/abstract-signer": ">=5.5.0",
+    "@ethersproject/address": "5.7.0",
     "@ethersproject/bignumber": ">=5.5.0",
     "@ethersproject/contracts": ">=5.5.0",
     "react-fast-compare": "3.2.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "@ethersproject/address": "5.7.0",
     "@ethersproject/bignumber": ">=5.5.0",
     "@ethersproject/contracts": ">=5.5.0",
-    "react-fast-compare": "3.2.0"
+    "react-fast-compare": "3.2.0",
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "7.0.1",

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -23,7 +23,7 @@ import {
 } from './types';
 
 export const DEPLOYMENT_AZRAEL_ETHEREUM_MAINNET_V0 = {
-  contractAddress: '0x94d8f036a0fbc216bb532d33bdf6564157af0cd7',
+  contractAddress: '0x94D8f036a0fbC216Bb532D33bDF6564157Af0cD7',
   network: NETWORK_ETHEREUM_MAINNET,
   contractType: RenftContractType.AZRAEL,
   version: AzraelVersion.V0,
@@ -48,7 +48,7 @@ export const DEPLOYMENT_SYLVESTER_POLYGON_MAINNET_V0 = {
 } as const;
 
 export const DEPLOYMENT_SYLVESTER_POLYGON_MAINNET_V1 = {
-  contractAddress: '0x4e52b73aa28b7ff84d88ea3a90c0668f46043450',
+  contractAddress: '0x4e52B73Aa28b7FF84d88eA3A90C0668f46043450',
   network: NETWORK_POLYGON_MAINNET,
   contractType: RenftContractType.SYLVESTER,
   version: SylvesterVersion.V1,
@@ -88,7 +88,7 @@ export const DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V0 = {
 } as const;
 
 export const DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V1 = {
-  contractAddress: '0x3ddc85bb768a11b0125f4ee71cfea54e54653366',
+  contractAddress: '0x3ddC85bB768A11B0125f4ee71CfeA54e54653366',
   network: NETWORK_POLYGON_MAINNET,
   contractType: RenftContractType.RESOLVER,
   version: ResolverVersion.V1,

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -149,7 +149,7 @@ export function isValidDeployment<T extends RenftContractDeployment>(
   deployment: T
 ): boolean {
   try {
-    return DeploymentSchema.safeParse(deployment).success;
+    return !!DeploymentSchema.parse(deployment);
   } catch (e) {
     console.warn(e);
 

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -26,9 +26,9 @@ import {
 import { getAddress } from '@ethersproject/address';
 
 export const DeploymentSchema = z.object({
-  contractAddress: z.string().refine((address: string) => getAddress(address), {
-    message: 'Deployment contract address must be a valid checksummed address',
-  }),
+  contractAddress: z
+    .string()
+    .transform((address: string) => getAddress(address)),
   network: z.object({
     chainId: z.number(),
     type: z.nativeEnum(EVMNetworkType),

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -72,7 +72,7 @@ export const DEPLOYMENT_WHOOPI_AVALANCHE_MAINNET_V0 = {
 } as const;
 
 export const DEPLOYMENT_RESOLVER_ETHEREUM_MAINNET_V0 = {
-  contractAddress: '0x945e589a4715d1915e6fe14f08e4887bc4019341',
+  contractAddress: '0x945E589A4715d1915e6FE14f08e4887Bc4019341',
   network: NETWORK_ETHEREUM_MAINNET,
   contractType: RenftContractType.RESOLVER,
   version: ResolverVersion.V0,
@@ -125,6 +125,27 @@ export const RENFT_CONTRACT_DEPLOYMENTS: RenftContractDeployments = [
   DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V1,
 ];
 
+export function findSingleDeploymentOrThrow<T extends RenftContractDeployment>(
+  search: Partial<T>
+) {
+  const [deployment, ...rest] = findDeployments<T>(search);
+
+  if (!deployment)
+    throw new Error(
+      `[findSingleDeploymentOrThrow]: No deployment found for search: ${JSON.stringify(
+        search
+      )}`
+    );
+  if (rest.length)
+    throw new Error(
+      `[findSingleDeploymentOrThrow]: Multiple deployments found for search: ${JSON.stringify(
+        search
+      )}`
+    );
+
+  return deployment;
+}
+
 export function findDeployments<T extends RenftContractDeployment>(
   search: Partial<T>
 ) {
@@ -148,23 +169,9 @@ export function findDeployments<T extends RenftContractDeployment>(
 export function getContractAddressForDeployment<
   T extends RenftContractDeployment
 >(search: Omit<Partial<T>, 'contractAddress'>): string {
-  const matchingDeployments = findDeployments<T>(search as Partial<T>);
-
-  if (!matchingDeployments.length)
-    throw new Error(
-      `[getContractAddressForDeployment]: Failed to find a matching deployment for search: ${JSON.stringify(
-        search
-      )}`
-    );
-
-  if (matchingDeployments.length > 1)
-    throw new Error(
-      `[getContractAddressForDeployment]: Found multiple possible deployments for search: ${JSON.stringify(
-        search
-      )}`
-    );
-
-  const [matchingDeployment] = matchingDeployments;
+  const matchingDeployment = findSingleDeploymentOrThrow<T>(
+    search as Partial<T>
+  );
 
   const { contractAddress } = matchingDeployment!;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export * from './utils';
 
 // TODO: These exports are now deprecated. Remove them and have the consumer compute them dynamically.
 
-/*
+/**
  * @deprecated Use RESOLVER_ETHEREUM_ADDRESS instead
  */
 export const RESOLVER_ADDRESS = '0x945e589a4715d1915e6fe14f08e4887bc4019341';
@@ -45,7 +45,7 @@ export const RESOLVER_AVALANCHE_ADDRESS = getContractAddressForDeployment({
   contractType: RenftContractType.RESOLVER,
 });
 
-/*
+/**
  * @deprecated Use AZRAEL_ETHEREUM_ADDRESS instead
  */
 export const AZRAEL_ADDRESS = '0x94d8f036a0fbc216bb532d33bdf6564157af0cd7';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,12 @@ export * from './utils';
 
 // TODO: These exports are now deprecated. Remove them and have the consumer compute them dynamically.
 
-export const RESOLVER_ADDRESS = getContractAddressForDeployment({
+/*
+ * @deprecated Use RESOLVER_ETHEREUM_ADDRESS instead
+ */
+export const RESOLVER_ADDRESS = '0x945e589a4715d1915e6fe14f08e4887bc4019341';
+
+export const RESOLVER_ETHEREUM_ADDRESS = getContractAddressForDeployment({
   network: NETWORK_ETHEREUM_MAINNET,
   contractType: RenftContractType.RESOLVER,
 });
@@ -40,7 +45,12 @@ export const RESOLVER_AVALANCHE_ADDRESS = getContractAddressForDeployment({
   contractType: RenftContractType.RESOLVER,
 });
 
-export const AZRAEL_ADDRESS = getContractAddressForDeployment({
+/*
+ * @deprecated Use AZRAEL_ETHEREUM_ADDRESS instead
+ */
+export const AZRAEL_ADDRESS = '0x94d8f036a0fbc216bb532d33bdf6564157af0cd7';
+
+export const AZRAEL_ETHEREUM_ADDRESS = getContractAddressForDeployment({
   network: NETWORK_ETHEREUM_MAINNET,
   contractType: RenftContractType.AZRAEL,
 });

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -24,7 +24,7 @@ import {
 describe('deprecated contract addresses', () => {
   it('should not invalidate current consumers', () => {
     expect(RESOLVER_ADDRESS).to.equal(
-      '0x945e589a4715d1915e6fe14f08e4887bc4019341'
+      '0x945E589A4715d1915e6FE14f08e4887Bc4019341'
     );
     expect(AZRAEL_ADDRESS).to.equal(
       '0x94d8f036a0fbc216bb532d33bdf6564157af0cd7'

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -19,16 +19,26 @@ import {
   WhoopiV0FunctionInterface,
   DEPLOYMENT_SYLVESTER_POLYGON_MAINNET_V1,
   SylvesterV1FunctionInterface,
+  RESOLVER_ETHEREUM_ADDRESS,
+  AZRAEL_ETHEREUM_ADDRESS,
 } from '../src';
 
 describe('deprecated contract addresses', () => {
   it('should not invalidate current consumers', () => {
     expect(RESOLVER_ADDRESS).to.equal(
+      '0x945e589a4715d1915e6fe14f08e4887bc4019341'
+    );
+    expect(RESOLVER_ETHEREUM_ADDRESS).to.equal(
       '0x945E589A4715d1915e6FE14f08e4887Bc4019341'
     );
+    expect(RESOLVER_ETHEREUM_ADDRESS).to.not.equal(RESOLVER_ADDRESS);
     expect(AZRAEL_ADDRESS).to.equal(
+      '0x94d8f036a0fbc216bb532d33bdf6564157af0cd7'
+    );
+    expect(AZRAEL_ETHEREUM_ADDRESS).to.equal(
       '0x94D8f036a0fbC216Bb532D33bDF6564157Af0cD7'
     );
+    expect(AZRAEL_ETHEREUM_ADDRESS).to.not.equal(AZRAEL_ADDRESS);
     expect(SYLVESTER_ADDRESS).to.equal(
       '0xa8D3F65b6E2922fED1430b77aC2b557e1fa8DA4a'
     );

--- a/test/consts.test.ts
+++ b/test/consts.test.ts
@@ -27,7 +27,7 @@ describe('deprecated contract addresses', () => {
       '0x945E589A4715d1915e6FE14f08e4887Bc4019341'
     );
     expect(AZRAEL_ADDRESS).to.equal(
-      '0x94d8f036a0fbc216bb532d33bdf6564157af0cd7'
+      '0x94D8f036a0fbC216Bb532D33bDF6564157Af0cD7'
     );
     expect(SYLVESTER_ADDRESS).to.equal(
       '0xa8D3F65b6E2922fED1430b77aC2b557e1fa8DA4a'

--- a/test/deployment.utils.test.ts
+++ b/test/deployment.utils.test.ts
@@ -1,4 +1,4 @@
-import { getAddress, isAddress } from '@ethersproject/address';
+import { getAddress } from '@ethersproject/address';
 import { expect } from 'chai';
 
 import {
@@ -11,8 +11,9 @@ import {
 describe('deployments', () => {
   it('addresses are checksummed', () => {
     expect(
-      RENFT_CONTRACT_DEPLOYMENTS.map(deployment =>
-        isAddress(getAddress(deployment.contractAddress))
+      RENFT_CONTRACT_DEPLOYMENTS.map(
+        deployment =>
+          deployment.contractAddress === getAddress(deployment.contractAddress)
       ).every(Boolean)
     ).to.be.true;
   });

--- a/test/deployment.utils.test.ts
+++ b/test/deployment.utils.test.ts
@@ -1,4 +1,4 @@
-import { isAddress } from '@ethersproject/address';
+import { getAddress, isAddress } from '@ethersproject/address';
 import { expect } from 'chai';
 
 import {
@@ -12,7 +12,7 @@ describe('deployments', () => {
   it('addresses are checksummed', () => {
     expect(
       RENFT_CONTRACT_DEPLOYMENTS.map(deployment =>
-        isAddress(deployment.contractAddress)
+        isAddress(getAddress(deployment.contractAddress))
       ).every(Boolean)
     ).to.be.true;
   });

--- a/test/deployment.utils.test.ts
+++ b/test/deployment.utils.test.ts
@@ -1,21 +1,39 @@
-import { getAddress } from '@ethersproject/address';
 import { expect } from 'chai';
 
 import {
   DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V1,
   findSingleDeploymentOrThrow,
+  isValidDeployment,
   RenftContractType,
   RENFT_CONTRACT_DEPLOYMENTS,
 } from '../src';
 
 describe('deployments', () => {
-  it('addresses are checksummed', () => {
-    expect(
-      RENFT_CONTRACT_DEPLOYMENTS.map(
-        deployment =>
-          deployment.contractAddress === getAddress(deployment.contractAddress)
-      ).every(Boolean)
-    ).to.be.true;
+  const validDeployment = DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V1;
+
+  it('all deployments are valid', () => {
+    expect(RENFT_CONTRACT_DEPLOYMENTS.map(isValidDeployment).every(Boolean)).to
+      .be.true;
+  });
+
+  describe('isValidDeployment', () => {
+    it('false for invalid contractAddress', () => {
+      expect(
+        isValidDeployment({
+          ...validDeployment,
+          contractAddress: '0x0000000',
+        })
+      ).to.be.false;
+    });
+
+    it('false for invalid startBlock', () => {
+      expect(
+        isValidDeployment({
+          ...validDeployment,
+          startBlock: -1,
+        })
+      ).to.be.false;
+    });
   });
 
   describe('findSingleDeploymentOrThrow', () => {
@@ -34,12 +52,11 @@ describe('deployments', () => {
     });
 
     it('finds by contract address', () => {
-      const deployment = DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V1;
       expect(
         findSingleDeploymentOrThrow({
-          contractAddress: deployment.contractAddress,
+          contractAddress: validDeployment.contractAddress,
         })
-      ).to.equal(deployment);
+      ).to.equal(validDeployment);
     });
   });
 });

--- a/test/deployment.utils.test.ts
+++ b/test/deployment.utils.test.ts
@@ -17,6 +17,15 @@ describe('deployments', () => {
   });
 
   describe('isValidDeployment', () => {
+    it('false for incorrectly checksummed contractAddress', () => {
+      expect(
+        isValidDeployment({
+          ...validDeployment,
+          contractAddress: '0x94D8f036a0fbC216bb532d33bDF6564157Af0cD7',
+        })
+      ).to.be.false;
+    });
+
     it('false for invalid contractAddress', () => {
       expect(
         isValidDeployment({

--- a/test/deployment.utils.test.ts
+++ b/test/deployment.utils.test.ts
@@ -1,0 +1,44 @@
+import { isAddress } from '@ethersproject/address';
+import { expect } from 'chai';
+
+import {
+  DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V1,
+  findSingleDeploymentOrThrow,
+  RenftContractType,
+  RENFT_CONTRACT_DEPLOYMENTS,
+} from '../src';
+
+describe('deployments', () => {
+  it('addresses are checksummed', () => {
+    expect(
+      RENFT_CONTRACT_DEPLOYMENTS.map(deployment =>
+        isAddress(deployment.contractAddress)
+      ).every(Boolean)
+    ).to.be.true;
+  });
+
+  describe('findSingleDeploymentOrThrow', () => {
+    it('throws if no deployment found', () => {
+      expect(() =>
+        findSingleDeploymentOrThrow({ contractAddress: '0x0000000' })
+      ).to.throw();
+    });
+
+    it('throws if multiple deployments found', () => {
+      expect(() =>
+        findSingleDeploymentOrThrow({
+          contractType: RenftContractType.RESOLVER,
+        })
+      ).to.throw();
+    });
+
+    it('finds by contract address', () => {
+      const deployment = DEPLOYMENT_RESOLVER_POLYGON_MAINNET_V1;
+      expect(
+        findSingleDeploymentOrThrow({
+          contractAddress: deployment.contractAddress,
+        })
+      ).to.equal(deployment);
+    });
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,4 @@
 import { Signer } from '@ethersproject/abstract-signer';
-import { isAddress } from '@ethersproject/address';
 import { expect } from 'chai';
 import isEqual from 'react-fast-compare';
 
@@ -16,7 +15,6 @@ import {
   DEPLOYMENT_WHOOPI_AVALANCHE_MAINNET_V0,
   getDeploymentAbi,
   getRenftContract,
-  RENFT_CONTRACT_DEPLOYMENTS,
 } from '../src';
 
 import azrael_v0 from '../src/abi/azrael.v0.abi.json';
@@ -92,12 +90,5 @@ describe('module exports', () => {
     // HACK: Here we ensure that the returned interface matches the provided deployment.
     const azrael: AzraelV0FunctionInterface = renft;
     expect(!!azrael).to.be.true;
-  });
-  it('deployment addresses are checksummed', () => {
-    expect(
-      RENFT_CONTRACT_DEPLOYMENTS.map(deployment =>
-        isAddress(deployment.contractAddress)
-      ).every(Boolean)
-    ).to.be.true;
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import { Signer } from '@ethersproject/abstract-signer';
+import { isAddress } from '@ethersproject/address';
 import { expect } from 'chai';
 import isEqual from 'react-fast-compare';
 
@@ -15,6 +16,7 @@ import {
   DEPLOYMENT_WHOOPI_AVALANCHE_MAINNET_V0,
   getDeploymentAbi,
   getRenftContract,
+  RENFT_CONTRACT_DEPLOYMENTS,
 } from '../src';
 
 import azrael_v0 from '../src/abi/azrael.v0.abi.json';
@@ -90,5 +92,12 @@ describe('module exports', () => {
     // HACK: Here we ensure that the returned interface matches the provided deployment.
     const azrael: AzraelV0FunctionInterface = renft;
     expect(!!azrael).to.be.true;
+  });
+  it('deployment addresses are checksummed', () => {
+    expect(
+      RENFT_CONTRACT_DEPLOYMENTS.map(deployment =>
+        isAddress(deployment.contractAddress)
+      ).every(Boolean)
+    ).to.be.true;
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,17 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
 
+"@ethersproject/address@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
 "@ethersproject/address@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
@@ -983,12 +994,28 @@
     "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
   integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/constants@^5.5.0":
   version "5.5.0"
@@ -1035,10 +1062,23 @@
     "@ethersproject/bytes" "^5.5.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+
+"@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
 "@ethersproject/networks@^5.5.0":
   version "5.5.0"
@@ -1061,6 +1101,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/signing-key@^5.5.0":
   version "5.5.0"
@@ -2005,6 +2053,11 @@ bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6937,3 +6937,8 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+zod@3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
# Changes included:
- All reNFT deployment addresses are now in checksummed address format.
- `findSingleDeploymentOrThrow()` method has been introduced
- `isValidDeployment()` method has been introduced. -> Uses zod schema to verify deployments are valid.


# Testing:
Replaced all `@renft/sdk` package.json dependencies with this version locally.
- Manually tested `stopLend` transaction on Avalanche with reNFT dev wallet (https://snowtrace.io/tx/0xd3578d7a92d72cdfef1adf4500e74412eac2cd1690316b04b2940caabe598c3f)
- Manually tested `lend` transaction on polygon with reNFT dev wallet (https://polygonscan.com/tx/0x8162b7b6707489fab159baf6144edcdd9e4dd9af6f801feb8bf1abc5f82ed3fe)
- Manually tested `stopLend` transaction on polygon with reNFT dev wallet (https://polygonscan.com/tx/0xf34d4fa1a87c1ba803ce03d1b59c0a961cf80d12bb2d11293aa48cccf82e951d)
- `yarn e2e test` passing
- `yarn test` passing.