### PR TITLE
Minor README update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [7.0.1] - 2023-06-09
+
+## Changed
+
+- How we import utils from `viem` in one place
+- Wording around contracts flavors in readme
+
 ## [7.0.0] - 2023-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ## Changed
 
-- How we import utils from `viem` in one place
 - Wording around contracts flavors in readme
 
 ## [7.0.0] - 2023-06-08

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The below is a simple example of lending an ERC721, note that the amount is igno
 
 If you are having any issues with the below code, go [here](https://github.com/re-nft/sdk/tree/main/examples) and ensure your dependencies for `ethersproject` are the same as ours (in `package.json`).
 
-You might be wondering what 'AZRAEL' refers to in the below import. If so, go to our docs [here](https://docs.renft.io/developers/renft-contracts-addresses). Azrael, Sylvester and Whoopi are our naming conventions to refer to different versions of our contracts.
+You might be wondering what 'AZRAEL' refers to in the below import. If so, go to our docs [here](https://docs.renft.io/developers/renft-contracts-addresses). Azrael, Sylvester and Whoopi are our naming conventions to refer to different flavors of our contracts.
 
 ## `@renft/sdk/viem`
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.0",
+  "version": "7.0.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/viem/interfaces/Whoopi.v0.ts
+++ b/src/viem/interfaces/Whoopi.v0.ts
@@ -1,4 +1,4 @@
-import { parseUnits } from 'viem/utils';
+import { parseUnits } from 'viem';
 
 import { NETWORK_RESOLVERS } from '../../core';
 import {

--- a/src/viem/interfaces/Whoopi.v0.ts
+++ b/src/viem/interfaces/Whoopi.v0.ts
@@ -1,4 +1,4 @@
-import { parseUnits } from 'viem';
+import { parseUnits } from 'viem/utils';
 
 import { NETWORK_RESOLVERS } from '../../core';
 import {


### PR DESCRIPTION
We had builds complaining that `viem/utils` couldn't be found.