### PR TITLE
Version 7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [7.0.2] - 2023-06-09
+
+- Allowed `account` initialization parameter to allow `Account | Address`
+- Build multiple entrypoints 🤞
+- Removed unused var in `examples/viem/readme.example.ts`
+
 ## [7.0.1] - 2023-06-09
 
 ## Changed
@@ -94,6 +100,6 @@ Nothing.
 
 ### Changed
 
-- All reNFT deployment addresses are now in checksummed address format.
+- All RENET deployment addresses are now in checksummed address format.
 - Deprecated `RESOLVER_ADDRESS` in favor of `RESOLVER_ETHEREUM_ADDRESS`
 - Deprecated `AZRAEL_ADDRESS` in favor of `AZRAEL_ETHEREUM_ADDRESS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,6 @@ Nothing.
 
 ### Changed
 
-- All RENET deployment addresses are now in checksummed address format.
+- All reNFT deployment addresses are now in checksummed address format.
 - Deprecated `RESOLVER_ADDRESS` in favor of `RESOLVER_ETHEREUM_ADDRESS`
 - Deprecated `AZRAEL_ADDRESS` in favor of `AZRAEL_ETHEREUM_ADDRESS`

--- a/examples/src/viem/readme.example.ts
+++ b/examples/src/viem/readme.example.ts
@@ -36,7 +36,6 @@ const main = async () => {
   const lendAmount = [1];
   const maxRentDuration = [1];
   const dailyRentPrice = [1.1];
-  const nftPrice = [2.2];
   const paymentToken = [PaymentToken.WETH];
 
   const nftStandard = [1, 1];

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.1",
+  "version": "7.0.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pre-commit": "yarn format && yarn lint && yarn build",
     "pre-push": "yarn test",
     "start": "tsdx watch",
-    "build": "tsdx build",
+    "build": "tsdx build -i src/index.ts -i src/abi/index.ts -i src/core/index.ts -i src/ethers/index.ts -i src/viem/index.ts",
     "test": "tsdx test",
     "lint": "tsdx lint src",
     "format": "prettier --write './src/**/*' './test/**/*'",

--- a/src/viem/base.ts
+++ b/src/viem/base.ts
@@ -1,5 +1,6 @@
 import {
   Account,
+  Address,
   PublicClient,
   SimulateContractReturnType,
   WalletClient,
@@ -28,7 +29,7 @@ export type SDKInterface<
   ContractType extends RenftContractType,
   ContractVersion extends RenftContractVersions[ContractType]
 > = {
-  account: Account;
+  account: Account | Address;
   deployment: Deployment<ContractType, ContractVersion>;
   publicClient: PublicClient;
   walletClient: WalletClient;


### PR DESCRIPTION
An issue popped up where when using `wagmi` we don't have access to the full `account` object. `viem` allows this to be an `Address` (`0x${string}`) in many calls. We should support this. An additional issue was that our multiple entrypoints didn't seem to work. I believe passing these to `tsdx build` fixes this. If not we should release a `7.0.3` instructing consumers to just import from the main `@renft/sdk` entrypoint.