### PR TITLE
Revert `yarn build` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [7.0.3] - 2023-06-21
+
+- Reverted `yarn build` command to build the complete `src/` directory instead of separate modules. The previous build command gobbled up `enum` as `const` exports and only provided their types.
+- Updated examples to utilize correct import paths.
+
 ## [7.0.2] - 2023-06-09
 
 - Allowed `account` initialization parameter to allow `Account | Address`

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ You might be wondering what 'AZRAEL' refers to in the below import. If so, go to
 
 ```javascript
 import {
+  AzraelV0SDK,
   DEPLOYMENT_AZRAEL_ETHEREUM_MAINNET_V0,
   PaymentToken,
-} from '@renft/sdk/core';
-import { AzraelV0SDK } from '@renft/sdk/viem';
+} from '@renft/sdk';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { mainnet } from 'viem/chains';

--- a/examples/src/viem/readme.example.ts
+++ b/examples/src/viem/readme.example.ts
@@ -1,8 +1,8 @@
 import {
   DEPLOYMENT_SYLVESTER_ETHEREUM_MAINNET_V0,
   PaymentToken,
-} from '@renft/sdk/core';
-import { SylvesterV0SDK } from '@renft/sdk/viem';
+  SylvesterV0SDK,
+} from '@renft/sdk';
 import { createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { mainnet } from 'viem/chains';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.2",
+  "version": "7.0.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -14,7 +14,7 @@
     "pre-commit": "yarn format && yarn lint && yarn build",
     "pre-push": "yarn test",
     "start": "tsdx watch",
-    "build": "tsdx build -i src/index.ts -i src/abi/index.ts -i src/core/index.ts -i src/ethers/index.ts -i src/viem/index.ts",
+    "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint src",
     "format": "prettier --write './src/**/*' './test/**/*'",


### PR DESCRIPTION
Apparently multiple entry points caused our `enum`s to be gobbled up by TypeScript, only exporting their types and not their `const` counterparts.